### PR TITLE
fix: HAWNG-497 Update RHBOAC for Quarkus version to 4.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     <!-- Jolokia -->
     <jolokia-version>2.0.2</jolokia-version>
     <!-- Quarkus -->
-    <quarkus-version>3.2.11.Final-redhat-00001</quarkus-version>
-    <quarkus-extension-version>3.2.11.Final-redhat-00001</quarkus-extension-version>
+    <quarkus-version>3.8.4.SP1-redhat-00001</quarkus-version>
+    <quarkus-extension-version>3.8.4.redhat-00002</quarkus-extension-version>
     <!-- Spring -->
     <!-- https://docs.spring.io/spring-boot/docs/3.2.5/reference/html/dependency-versions.html -->
     <spring-version>6.1.6</spring-version>


### PR DESCRIPTION
pr_rerun HAWNG-497-update-ceq-versions to 4.x-redhat